### PR TITLE
Refactor: Serve client files from Node.js server

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,21 +21,19 @@ This project implements a simple WebRTC video and audio calling website with a N
     npm start
     ```
     Alternatively, you can run `node server.js`.
-    The server will start on `ws://localhost:8080` by default. You should see a log message: `Signaling server started on port 8080`.
+    The server will start and be accessible via HTTP (e.g., `http://localhost:8080`) and WebSockets on the same port.
+    You should see log messages like:
+    `Server running on http://localhost:8080`
+    `WebSocket server is also attached and listening on port 8080`
 
-### Client Setup
+### Accessing the Application
 
-1.  **Serve Client Files:**
-    The client-side files (`index.html`, `app.js`, `style.css`) need to be served by a simple HTTP server. You can use various tools for this, for example:
-    *   **Using Python:** If you have Python installed, navigate to the project root and run:
-        *   Python 3: `python -m http.server`
-        *   Python 2: `python -m SimpleHTTPServer`
-        This will typically serve files on `http://localhost:8000`.
-    *   **Using VS Code Live Server:** If you are using Visual Studio Code, the "Live Server" extension is a convenient way to serve the files.
-    *   Other HTTP server tools can also be used.
-
-2.  **Access the Application:**
-    Open a web browser (Chrome or Firefox are recommended for good WebRTC support) and navigate to the address where the client files are being served (e.g., `http://localhost:8000` if using Python's http.server on the default port).
+1.  **Open in Browser:**
+    After starting the server, open a web browser (Chrome or Firefox are recommended for good WebRTC support).
+2.  **Navigate to Server Address:**
+    Navigate to the address of the running Node.js server. If it's running locally on the default port, this will be:
+    `http://localhost:8080`
+    The `server.js` script now directly serves the `index.html` page and other client assets (`app.js`, `style.css`). You no longer need a separate HTTP server for the client files.
 
 ### How to Use
 
@@ -55,7 +53,6 @@ This project implements a simple WebRTC video and audio calling website with a N
 
 ### Notes for Agent
 
-*   The `server.js` handles signaling and does not use a database, storing user sessions in memory.
-*   `app.js` contains all client-side WebRTC and signaling logic.
-*   Ensure the WebSocket server (default `ws://localhost:8080`) is accessible to the client. If you change the server port or run it on a different machine, update the `wsUrl` in `app.js` accordingly.
+*   The `server.js` now handles both HTTP static file serving (for `index.html`, `app.js`, `style.css`) and WebSocket signaling. It does not use a database, storing user sessions in memory.
+*   `app.js` contains all client-side WebRTC and signaling logic. The WebSocket URL in `app.js` is now dynamically constructed to connect to the same host and port that served the HTTP files.
 *   The application uses STUN servers from Google for NAT traversal. For more robust connections, especially across complex networks, a TURN server might be needed (not included in this setup).

--- a/app.js
+++ b/app.js
@@ -35,10 +35,12 @@ async function init() {
     // Determine WebSocket protocol (ws or wss)
     const wsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
     // Construct WebSocket URL (assuming server.js is running on the same host and port 8080)
-    // For local development, you might run the HTTP server on one port (e.g., 8000 or from a live server extension)
-    // and the WebSocket server on another (e.g., 8080).
-    // Adjust if your setup is different.
-    const wsUrl = `${wsProtocol}//${window.location.hostname}:8080`;
+    // Construct WebSocket URL. It will connect to the same host and port
+    // as the HTTP server that served the page.
+    let wsUrl = `${wsProtocol}//${window.location.hostname}`;
+    if (window.location.port) { // Add port only if it's specified
+        wsUrl += `:${window.location.port}`;
+    }
 
     console.log(`Attempting to connect to WebSocket server at ${wsUrl}`);
     ws = new WebSocket(wsUrl);


### PR DESCRIPTION
- Modified server.js to include an HTTP server for serving static client files (index.html, app.js, style.css) alongside the WebSocket signaling server.
- Both HTTP and WebSocket services now run on the same port.
- Updated app.js to dynamically determine the WebSocket connection URL based on window.location, removing the hardcoded port.
- Updated AGENTS.md to reflect that a separate HTTP server is no longer needed and users can access the application directly via the Node.js server URL.